### PR TITLE
Fix extraPercent to be proportional to in-view bounds, improving zoomed-in performance

### DIFF
--- a/lib/src/utils/boudaries.dart
+++ b/lib/src/utils/boudaries.dart
@@ -1,7 +1,0 @@
-class Boundaries {
-  final double min, max;
-
-  const Boundaries(double a, double b)
-      : min = a > b ? b : a,
-        max = a > b ? a : b;
-}

--- a/lib/src/utils/extensions.dart
+++ b/lib/src/utils/extensions.dart
@@ -1,5 +1,0 @@
-extension PercentageExtensions on num {
-  num addPercentage(num percent) => this + (this * percent).abs();
-
-  num removePercentage(num percent) => this - (this * percent).abs();
-}


### PR DESCRIPTION
Hi @bpillon great library and easy to use. However I did find that with a large number of places (~2000) to display the performance was a bit slow at high zoom levels. For example, clustering took more than 500ms at zoom level 16 on a Galaxy S10 Plus. 

The cause of the delay seemed to be a large number of items being determined as visible by the `getMarkers` function, which at high zoom levels required longer geohashing comparisons for clustering. 

I'm based in Sydney (-33°, 150°), so the current approach of scaling the `LatLngBounds` directly with `extraPercent=0.2` resulted in the 'in view' region being a good fraction of the country: (-27°, 120°) -> (-39°, 180°) no matter how far the user had zoomed in. 

This pull request uses a different method to expand the LatLng boundaries for determining in view places, where the amount that the boundaries are expanded is proportional to the size of the area in view so that only nearby places are included in the clustering. 

I found a 50% expansion to be a pretty decent default value to prevent clusters popping in during typical use of dragging the map around. 

Have a look and let me know what you think. 