### PR TITLE
Minor changes

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  google_maps_flutter_platform_interface: ^2.1.0
+  google_maps_flutter_platform_interface: ^2.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- add a parameter to block update on set/add items to enable the possibility to make some calculations on clustered markers
- expose inflateBounds

The first edit, is to provide the flexibility to (for example) add markers to cluster calculation and then, do some work for items non grouped in cluster or yes.
For example: I have an app that, before adding the marker to the map, calculate a value server side and put this value in a custom marker. Obviously, this value is useless to be calculated if the marker is inside a cluster. With this change, I can pass the items to the lib, calculate the clusters and single items, and then call the server side only for single markers. Is an improvement retro-compatible.