### PR TITLE
fix: ClusterManager.setItems can be iterable

### DIFF
--- a/lib/src/cluster_manager.dart
+++ b/lib/src/cluster_manager.dart
@@ -88,7 +88,7 @@ class ClusterManager<T extends ClusterItem> {
   }
 
   /// Update all cluster items
-  void setItems(List<T> newItems) {
+  void setItems(Iterable<T> newItems) {
     _items = newItems;
     updateMap();
   }


### PR DESCRIPTION
Hi,

Thank you for this awesome library!

I would like to suggest one small improvement: allow items can be iterable for ClusterManager.setItems.

Will glad for your review.

My best regards,
Anton