### PR TITLE
fix import conflicts from google_maps_flutter_platform_interface

### DIFF
--- a/lib/src/cluster_item.dart
+++ b/lib/src/cluster_item.dart
@@ -1,5 +1,6 @@
 import 'package:google_maps_cluster_manager/google_maps_cluster_manager.dart';
-import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart'
+    hide ClusterManager;
 
 mixin ClusterItem {
   LatLng get location;

--- a/lib/src/cluster_manager.dart
+++ b/lib/src/cluster_manager.dart
@@ -5,7 +5,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_cluster_manager/google_maps_cluster_manager.dart';
 import 'package:google_maps_cluster_manager/src/max_dist_clustering.dart';
-import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart'
+    hide Cluster;
 
 enum ClusterAlgorithm { GEOHASH, MAX_DIST }
 


### PR DESCRIPTION
Hide ClusterManager and Cluster classes from google_maps_flutter_platform_interface to fix import conflicts